### PR TITLE
enable setting 'hide_before_open' for all screenshot commands

### DIFF
--- a/extensions/infinilabs/screenshot/plugin.json
+++ b/extensions/infinilabs/screenshot/plugin.json
@@ -3,6 +3,9 @@
   "description": "Provides various commands for taking screenshots on macOS.",
   "icon": "icon.png",
   "type": "extension",
+  "version": {
+    "number": "0.1.1"
+  },
   "category": "Utilities",
   "tags": [
     "Productivity"
@@ -27,6 +30,9 @@
         "args": [
           "-p"
         ]
+      },
+      "settings": {
+        "hide_before_open": true
       }
     },
     {
@@ -40,6 +46,9 @@
           "-i",
           "-p"
         ]
+      },
+      "settings": {
+        "hide_before_open": true
       }
     },
     {
@@ -53,6 +62,9 @@
           "-w",
           "-p"
         ]
+      },
+      "settings": {
+        "hide_before_open": true
       }
     },
     {
@@ -66,6 +78,9 @@
           "-i",
           "-c"
         ]
+      },
+      "settings": {
+        "hide_before_open": true
       }
     },
     {
@@ -80,6 +95,9 @@
           "-p",
           "-c"
         ]
+      },
+      "settings": {
+        "hide_before_open": true
       }
     }
   ]


### PR DESCRIPTION
In commit https://github.com/infinilabs/coco-app/commit/ee75f0d119c63911bd2d26252dce3f03e6544665, we added a new setting entry "hide_before_open", which, if set for an extension, Coco would hide the main window before opening/executing the extension.  We implement this setting primarily for the screenshot extension, see the discussion[1].

This commit enables this setting for all the commands of the screenshot extension and bumps the extension version to '0.1.1'.

[1]: https://github.com/infinilabs/coco-app/issues/842