### PR TITLE
refactor: only empty trash if it is not empty

### DIFF
--- a/extensions/infinilabs/empty_trash/plugin.json
+++ b/extensions/infinilabs/empty_trash/plugin.json
@@ -20,7 +20,7 @@
     "exec": "zsh",
     "args": [
       "-c",
-      "osascript -e 'try' -e 'tell application \"Finder\" to empty' -e 'end try'"
+      "osascript -e 'tell application \"Finder\" to if (count items in trash) > 0 then empty trash'"
     ]
   },
   "category": "Utilities",


### PR DESCRIPTION
On macOS 26.0.1, running this command while the Trash is empty causes it to hang for several seconds. I’m not sure why, but it’s easy to fix: only empty the Trash when it isn’t empty.